### PR TITLE
Fix typo in changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ To be released.
 
  -  Updated Unicode Han Database `kHangul` data
     (*src/Text/Seonbi/Unicode/kHangul.json*) to the version 16.0.0.
-    [[36] by Lee Dogeon]
+    [[#36] by Lee Dogeon]
 
 [#36]: https://github.com/dahlia/seonbi/pull/36
 


### PR DESCRIPTION
This pull request fixes a typo in CHANGES.md, `[36]` → `[#36]`. Thanks for writing the changelog that I missed in #36. 🙏🏻